### PR TITLE
[DatePicker] - Add "required" attribute and md-error templating

### DIFF
--- a/src/component/date-picker/date-picker.component.html
+++ b/src/component/date-picker/date-picker.component.html
@@ -1,5 +1,5 @@
 <md-input-container id="date-selector">
-    <input #inputelement id="date-selector-input" mdInput [disabled]="disabled" [ngModel]="inputModel" (ngModelChange)="updateModel($event)" placeholder="{{placeholder}}" [textMask]="{mask: mask, showMask: true}">
+    <input #inputelement id="date-selector-input" mdInput [disabled]="disabled" [required]="required" [ngModel]="inputModel" (ngModelChange)="updateModel($event)" placeholder="{{placeholder}}" [textMask]="{mask: mask, showMask: true}">
 	<div mdSuffix>
 		<div id="action-icon-container">
 			<md-icon *ngIf="inputModel && !disabled" (click)="reset()" id="clear-button">clear</md-icon>
@@ -9,13 +9,16 @@
 	<md-hint *ngIf="mdHint">
 		<ng-template [ngTemplateOutlet]="mdHint"></ng-template>
 	</md-hint>
+	<md-error *ngIf="mdError">
+		<ng-template [ngTemplateOutlet]="mdError"></ng-template>
+	</md-error>
 </md-input-container>
 <deja-dropdown *ngIf="showDropDown" id="deja-dropdown" [containerElement]="containerElement" [ownerElement]="elementRef.nativeElement" [ownerAlignment]="ownerAlignment" [dropdownAlignment]="dropdownAlignment" ownerBottomMargin=-4>
-	<deja-date-time-selector 
-		[time]="time" 
-		[disableDates]="disableDates" 
-		[ngModel]="date" 
-		(ngModelChange)="onDateChange($event)" 
+	<deja-date-time-selector
+		[time]="time"
+		[disableDates]="disableDates"
+		[ngModel]="date"
+		(ngModelChange)="onDateChange($event)"
 		class="inside-dropdown"
 		[dateMax]="dateMax"
 		[dateMin]="dateMin"

--- a/src/component/date-picker/date-picker.component.ts
+++ b/src/component/date-picker/date-picker.component.ts
@@ -57,6 +57,8 @@ export class DejaDatePickerComponent implements OnInit, ControlValueAccessor, Af
     @ViewChild(DejaDateSelectorComponent) public dateSelectorComponent: DejaDateSelectorComponent;
     /** Template for MdHint inside md-input-container */
     @ContentChild('hintTemplate') protected mdHint;
+    /** Template for MdError inside md-input-container */
+    @ContentChild('errorTemplate') protected mdError;
     /** Mask for input */
     protected mask: any[];
 
@@ -64,6 +66,7 @@ export class DejaDatePickerComponent implements OnInit, ControlValueAccessor, Af
 
     private subscriptions = [] as Subscription[];
     private _disabled: boolean;
+    private _required: boolean;
     private _time: boolean;
     private _format: string;
     private inputElement$ = new ReplaySubject<HTMLElement>(1);
@@ -256,6 +259,18 @@ export class DejaDatePickerComponent implements OnInit, ControlValueAccessor, Af
     /** disabled property getter. */
     public get disabled() {
         return this._disabled;
+    }
+
+    /** required property setter. Can be string or empty so you can use it like : <deja-date-picker required></deja-date-picker> */
+    @Input()
+    public set required(value: boolean | string) {
+        this._required = (value != null && `${value}` !== 'false') ? true : null;
+        this.changeDetectorRef.markForCheck();
+    }
+
+    /** required property getter. */
+    public get required() {
+        return this._required;
     }
 
     /**


### PR DESCRIPTION
Add "required" attribute to automatically display the "*" in the component's label when using reactive forms
Add templating for md-error, enabling the display of an error message below the component