### PR TITLE
DejaAutosizeTextAreaDirective

### DIFF
--- a/src/component/autosize-textarea/autosize-textarea.directive.ts
+++ b/src/component/autosize-textarea/autosize-textarea.directive.ts
@@ -16,7 +16,6 @@ import { Subscription } from 'rxjs/Subscription';
  * Directive pour rendre un textarea material redimensioné automatiquement au contenu.
  * Implémentation (créer un champ mat-input-container>textarea et lui ajouter la directive deja-autosize
  * Attention, comme la directive utilise un validateur pour détecter les modifications de contenu du textarea, le textarea doit impérativement utiliser ngModel.
- * @deprecated use mat-autosize instead
  */
 @Directive({
     providers: [


### PR DESCRIPTION
feat(DejaAutosizeTextAreaDirective): Removed temporarily deprecated flag, until the material directive work correctly with reactive forms.