### PR TITLE
feat(MatIconService): service to register SVG icons to MatIconRegistry

### DIFF
--- a/demo/src/app/app.component.html
+++ b/demo/src/app/app.component.html
@@ -1,4 +1,4 @@
-<deja-sidenav headerText="DEJA-JS">
+<deja-sidenav headerText="DEJA-JS" headerSvgIcon="angular">
     <deja-sidenav-menu slimScroll>
         <mat-nav-list>
             <mat-list-item title="Home" routerLink="/home" routerLinkActive="active">

--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -7,6 +7,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, OnDestroy, ViewEncapsulation } from '@angular/core';
+import { MatIconService } from '@deja-js/component';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/operator/takeWhile';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
@@ -25,7 +26,7 @@ export class AppComponent implements OnDestroy {
     private theme$: BehaviorSubject<string>;
     private isAlive = true;
 
-    constructor() {
+    constructor(private matIconService: MatIconService) {
         try {
             this._theme = localStorage.getItem('dejajs-demo-color');
         } catch (_e) {
@@ -39,6 +40,8 @@ export class AppComponent implements OnDestroy {
         Observable.from(this.theme$)
             .takeWhile(() => this.isAlive)
             .subscribe((theme) => document.body.setAttribute('theme', theme));
+
+        matIconService.addSvgIcon('angular', '../assets/img/logo/angular.svg');
     }
 
     public get theme() {

--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule, Routes } from '@angular/router';
 import { DejaClipboardModule, DejaMaterialColorsModule, DejaSidenavModule, DejaSlimScrollModule } from '@deja-js/component';
+import { DejaMatIconModule } from '@deja-js/component';
 import { AppComponent } from './app.component';
 import { routing } from './app.routes';
 import { CountriesListService } from './services/countries-list.service';
@@ -37,6 +38,7 @@ import { PeopleService } from './services/people.service';
         MatListModule,
         MatMenuModule,
         DejaMaterialColorsModule,
+        DejaMatIconModule,
         DejaSidenavModule,
         DejaSlimScrollModule,
         DejaClipboardModule.forRoot(),

--- a/demo/src/assets/img/logo/angular.svg
+++ b/demo/src/assets/img/logo/angular.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 250 250" style="enable-background:new 0 0 250 250;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#DD0031;}
+	.st1{fill:#C3002F;}
+	.st2{fill:#FFFFFF;}
+</style>
+<g>
+	<polygon class="st0" points="125,30 125,30 125,30 31.9,63.2 46.1,186.3 125,230 125,230 125,230 203.9,186.3 218.1,63.2 	"/>
+	<polygon class="st1" points="125,30 125,52.2 125,52.1 125,153.4 125,153.4 125,230 125,230 203.9,186.3 218.1,63.2 125,30 	"/>
+	<path class="st2" d="M125,52.1L66.8,182.6h0h21.7h0l11.7-29.2h49.4l11.7,29.2h0h21.7h0L125,52.1L125,52.1L125,52.1L125,52.1
+		L125,52.1z M142,135.4H108l17-40.9L142,135.4z"/>
+</g>
+</svg>

--- a/src/common/core/index.ts
+++ b/src/common/core/index.ts
@@ -22,6 +22,7 @@ export * from './style/index';
 export * from './UUID';
 export * from './validation/index';
 export * from './overlay/index';
+export * from './mat-icon/index';
 export * from './media/index';
 export * from './text-metrics/index';
 export * from './resize-listener/index';

--- a/src/common/core/mat-icon/index.ts
+++ b/src/common/core/mat-icon/index.ts
@@ -1,0 +1,20 @@
+/*
+ *  @license
+ *  Copyright Hôpitaux Universitaires de Genève. All Rights Reserved.
+ *
+ *  Use of this source code is governed by an Apache-2.0 license that can be
+ *  found in the LICENSE file at https://github.com/DSI-HUG/dejajs-components/blob/master/LICENSE
+ */
+
+import { CommonModule } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
+import { NgModule } from '@angular/core';
+import { MatIconService } from './mat-icon.service';
+
+@NgModule({
+    imports: [CommonModule, HttpClientModule],
+    providers: [MatIconService],
+})
+export class DejaMatIconModule { }
+
+export * from './mat-icon.service';

--- a/src/common/core/mat-icon/mat-icon.service.ts
+++ b/src/common/core/mat-icon/mat-icon.service.ts
@@ -21,8 +21,8 @@ export class MatIconService {
      *
      * &lt;mat-icon svgIcon='my-svg-icon' &gt;&lt;/mat-icon&gt;
      *
-     * @param {string} iconName
-     * @param {string} iconUrl
+     * @param iconName
+     * @param iconUrl
      */
     public addSvgIcon(iconName: string, iconUrl: string) {
         this.iconRegistry.addSvgIcon(iconName,

--- a/src/common/core/mat-icon/mat-icon.service.ts
+++ b/src/common/core/mat-icon/mat-icon.service.ts
@@ -1,0 +1,31 @@
+/*
+ *  @license
+ *  Copyright Hôpitaux Universitaires de Genève. All Rights Reserved.
+ *
+ *  Use of this source code is governed by an Apache-2.0 license that can be
+ *  found in the LICENSE file at https://github.com/DSI-HUG/dejajs-components/blob/master/LICENSE
+ */
+
+import { Injectable } from '@angular/core';
+import { MatIconRegistry } from '@angular/material';
+import { DomSanitizer } from '@angular/platform-browser';
+
+@Injectable()
+export class MatIconService {
+
+    constructor(private iconRegistry: MatIconRegistry, private sanitizer: DomSanitizer) {
+    }
+
+    /**
+     * register an SVG icon to the MatIconRegistry, so that this icon can be used with the MatIcon component.
+     *
+     * &lt;mat-icon svgIcon='my-svg-icon' &gt;&lt;/mat-icon&gt;
+     *
+     * @param {string} iconName
+     * @param {string} iconUrl
+     */
+    public addSvgIcon(iconName: string, iconUrl: string) {
+        this.iconRegistry.addSvgIcon(iconName,
+            this.sanitizer.bypassSecurityTrustResourceUrl(iconUrl));
+    }
+}

--- a/src/component/sidenav/sidenav.component.html
+++ b/src/component/sidenav/sidenav.component.html
@@ -1,7 +1,8 @@
 <mat-sidenav-container [class.sidenav-hidden]="hidden" [class.sidenav-light]="!hidden && !sidenav.opened">
     <mat-sidenav #sidenav mode="side" [opened]="opened || null" [mode]="mode">
         <mat-toolbar class="header">
-            <mat-icon class="header-icon">{{headerIcon}}</mat-icon>
+            <mat-icon class="header-icon" *ngIf="headerSvgIcon" [svgIcon]="headerSvgIcon"></mat-icon>
+            <mat-icon class="header-icon" *ngIf="!headerSvgIcon">{{headerIcon}}</mat-icon>
             <span class="header-text">{{headerText}}</span>
             <button mat-icon-button class="header-menu-btn" (click)="sidenav.toggle()">
                 <mat-icon></mat-icon>

--- a/src/component/sidenav/sidenav.component.ts
+++ b/src/component/sidenav/sidenav.component.ts
@@ -28,7 +28,12 @@ export class DejaSidenavComponent implements OnInit, OnDestroy {
     public headerText = 'TITLE';
 
     @Input()
+    /** Will be ignored if headerSvgIcon is set */
     public headerIcon = 'face';
+
+    @Input()
+    /** If not null, will be used in place of headerIcon. */
+    public headerSvgIcon: string;
 
     public hidden = false;
     public title: string;


### PR DESCRIPTION
feat(MatIconService): service to register SVG icons to MatIconRegistry so that custom SVG icons can be used with MatIcon component, i.e &lt;mat-icon svgIcon='deja-icon' /&gt;

feat(DejaSidenavComponent): added headerSvgIcon property so that a custom Icon could be displayed in place of the headerIcon

This closes #345