### PR TITLE
List item alignment in deja-select

### DIFF
--- a/src/common/core/item-list/_item-list.scss
+++ b/src/common/core/item-list/_item-list.scss
@@ -21,12 +21,12 @@
 			max-height: 0 !important;
 			transition-timing-function: ease-out;
 		}
-		
+
 		#expandbtn {
-			width: 24px;
+			min-width: 24px;
 			cursor: pointer;
 		}
-		
+
 		&.parent {
 			&.collapsed {
 				#expandbtn {


### PR DESCRIPTION
fix: List item alignment was not preserved if the item content was too long