### PR TITLE
Fix CiruclarPickerComponent body class

### DIFF
--- a/projects/deja-js/component/circular-picker/circular-picker.component.ts
+++ b/projects/deja-js/component/circular-picker/circular-picker.component.ts
@@ -140,7 +140,7 @@ export class DejaCircularPickerComponent implements OnInit, ControlValueAccessor
                     const kill$ = new Subject();
 
                     if (!element.ownerDocument.body.className.match(/noselect/)) {
-                        element.ownerDocument.body.className += 'noselect';
+                        element.ownerDocument.body.classList.add('noselect');
                     }
 
                     const cancelMouse$ = observableMerge(kill$, observableFromEvent(element.ownerDocument, 'mouseup')).pipe(


### PR DESCRIPTION
fix(CiruclarPickerComponent): Use classList.add instead of className concatenation on body element to avoid concatenation error (missing white space)