### PR TITLE
fix(date-picker): replaced value undefined by null

### DIFF
--- a/projects/deja-js/component/date-picker/date-picker.component.ts
+++ b/projects/deja-js/component/date-picker/date-picker.component.ts
@@ -637,7 +637,7 @@ export class DejaDatePickerComponent extends _MatInputMixinBase implements OnIni
         timer(0).pipe(
             takeUntil(this.destroyed$)
         ).subscribe(() => {
-            this.value = undefined;
+            this.value = null;
             delete this._inputModel;
         });
         this.close();


### PR DESCRIPTION
* ngx-mask does not take in account the undefined value so we have to return a null instead.