### PR TITLE
fix(overlay): rework css class visibility (DEJS-965)

### DIFF
--- a/projects/deja-js/component/overlay/overlay.component.spec.ts
+++ b/projects/deja-js/component/overlay/overlay.component.spec.ts
@@ -106,6 +106,28 @@ describe('DejaOverlayComponent', () => {
         void expect(cdkBackdropContainerEl.classList.contains('cdk-overlay-opaque-backdrop')).toBeTruthy();
     });
 
+    it('should have overlay custom class when is visible', () => {
+        comp.overlayContainerClass = 'class1 class2';
+        comp.isVisible = true;
+        fixture.detectChanges();
+        const cdkOverlayContainerEl = document.querySelector('.cdk-overlay-container');
+        void expect(cdkOverlayContainerEl.classList.contains('deja-overlay-container')).toBeTruthy();
+        void expect(cdkOverlayContainerEl.classList.contains('class1')).toBeTruthy();
+        void expect(cdkOverlayContainerEl.classList.contains('class2')).toBeTruthy();
+    });
+
+    it('should not have overlay custom class when is not visible', () => {
+        comp.overlayContainerClass = 'class1 class2';
+        comp.isVisible = true;
+        fixture.detectChanges();
+        comp.isVisible = false;
+        fixture.detectChanges();
+        const cdkOverlayContainerEl = document.querySelector('.cdk-overlay-container');
+        void expect(cdkOverlayContainerEl.classList.contains('deja-overlay-container')).toBeTruthy();
+        void expect(cdkOverlayContainerEl.classList.contains('class1')).toBeFalsy();
+        void expect(cdkOverlayContainerEl.classList.contains('class2')).toBeFalsy();
+    });
+
     it('should have isVisible=true when invoking show() method', () => {
         fixture.detectChanges();
         void expect(comp.isVisible).toBeFalsy();

--- a/projects/deja-js/component/overlay/overlay.component.ts
+++ b/projects/deja-js/component/overlay/overlay.component.ts
@@ -64,14 +64,19 @@ export class DejaOverlayComponent extends Destroy {
             this._isVisible = isVisible;
 
             const containerElement = this.overlayContainer.getContainerElement();
+            const tokenToRemove = new Array<string>();
             containerElement.classList.forEach(token => {
                 if (!token.startsWith('cdk')) {
-                    containerElement.classList.remove(token);
+                    tokenToRemove.push(token);
                 }
             });
 
+            if (tokenToRemove.length) {
+                containerElement.classList.remove(...tokenToRemove);
+            }
+
             containerElement.classList.add('deja-overlay-container');
-            if (this.overlayContainerClass) {
+            if (this.isVisible && this.overlayContainerClass) {
                 this.overlayContainerClass.split(' ').forEach(className => {
                     containerElement.classList.add(className);
                 });

--- a/projects/deja-js/component/overlay/overlay.component.ts
+++ b/projects/deja-js/component/overlay/overlay.component.ts
@@ -64,16 +64,9 @@ export class DejaOverlayComponent extends Destroy {
             this._isVisible = isVisible;
 
             const containerElement = this.overlayContainer.getContainerElement();
-            const tokenToRemove = new Array<string>();
-            containerElement.classList.forEach(token => {
-                if (!token.startsWith('cdk')) {
-                    tokenToRemove.push(token);
-                }
-            });
-
-            if (tokenToRemove.length) {
-                containerElement.classList.remove(...tokenToRemove);
-            }
+            containerElement.className = Array.from(containerElement.classList)
+                .filter(token => token.startsWith('cdk'))
+                .join(' ');
 
             containerElement.classList.add('deja-overlay-container');
             if (this.isVisible && this.overlayContainerClass) {


### PR DESCRIPTION
* do not add custom css class when overlay is not visible
* fix css class cleaner loop

Le usecase du bug dans le ticket http://jira.hcuge.ch/browse/DEJS-965
Concernant le bug sur la boucle css : https://stackblitz.com/edit/typescript-lybnv6