### PR TITLE
chore(ci): improvements

### DIFF
--- a/.github/workflows/ci-ghpages.yml
+++ b/.github/workflows/ci-ghpages.yml
@@ -11,31 +11,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.PUBLISH_TOKEN }}
+        uses: actions/checkout@v3
+        
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
           registry-url: https://registry.npmjs.org/
           cache: npm
-      - name: Make sure npm is latest
+          
+      - name: Install latest npm
         run: npm install -g npm@latest
+        
       - name: Install dependencies
         run: npm clean-install
+        
       - name: Build lib
         run: npm run build:lib
+        
       - name: Build demo
         run: npm run build
+        
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.PUBLISH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist/demo
-          # Assign commit authorship to the official GH-Actions bot for deploys to `gh-pages` branch:
-          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
-          # The GH actions bot is used by default if you didn't specify the two fields.
-          # You can swap them out with your own user credentials.
-          user_name: github-actions[bot]
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/ci_publish.yml
+++ b/.github/workflows/ci_publish.yml
@@ -11,37 +11,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.PUBLISH_TOKEN }}
+        uses: actions/checkout@v3
+
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
           registry-url: https://registry.npmjs.org/
-      - name: Make sure npm is latest
+          
+      - name: Install latest npm
         run: npm install -g npm@latest
+        
       - name: Install dependencies
         run: npm clean-install
+        
       - name: Build
         run: npm run build:lib
+        
       - name: Lint
         run: npm run lint
+        
       - name: Semantic Release
+        env:
+            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+            NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run release:ci
-        env:
-            GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-            user_name: github-actions[bot]
-            user_email: 41898282+github-actions[bot]@users.noreply.github.com
-      - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-        run: npm publish ./dist/deja-js/component --access public
+        
       - name: Merge release back to develop
         if: github.ref == 'refs/heads/master'
         uses: everlytic/branch-merge@1.1.2
         with:
-          github_token: ${{ secrets.PUBLISH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           source_ref: 'master'
           target_branch: 'develop'
           commit_message_template: 'merge branch {source_ref} of github.com:DSI-HUG/dejajs-components into {target_branch} [skip ci]'


### PR DESCRIPTION
- upgrade `actions/checkout` and `actions/setup-node` to `v3`
- remove `PUBLISH_TOKEN` from the project and replace it with `GITHUB_TOKEN` which is already provided by GitHub
- remove `publish` step as it is already done by `semantic-release`
- remove `github-action-bot` info as it already the defaults